### PR TITLE
Fix segfault

### DIFF
--- a/ethzasl_icp_mapper/src/dynamic_mapper.cpp
+++ b/ethzasl_icp_mapper/src/dynamic_mapper.cpp
@@ -243,11 +243,6 @@ Mapper::Mapper(ros::NodeHandle& n, ros::NodeHandle& pn):
 	radiusFilter = PM::get().DataPointsFilterRegistrar.create("MaxDistDataPointsFilter", params);
 
 	// topic initializations
-	if (getParam<bool>("subscribe_scan", true))
-		scanSub = n.subscribe("scan", inputQueueSize, &Mapper::gotScan, this);
-	if (getParam<bool>("subscribe_cloud", true))
-		cloudSub = n.subscribe("cloud_in", inputQueueSize, &Mapper::gotCloud, this);
-
 	mapPub = n.advertise<sensor_msgs::PointCloud2>("point_map", 2, true);
 	scanPub = n.advertise<sensor_msgs::PointCloud2>("corrected_scan", 2, true);
 	outlierPub = n.advertise<sensor_msgs::PointCloud2>("outliers", 2, true);
@@ -265,6 +260,11 @@ Mapper::Mapper(ros::NodeHandle& n, ros::NodeHandle& pn):
 	getModeSrv = pn.advertiseService("get_mode", &Mapper::getMode, this);
 	getBoundedMapSrv = pn.advertiseService("get_bounded_map", &Mapper::getBoundedMap, this);
 	reloadAllYamlSrv= pn.advertiseService("reload_all_yaml", &Mapper::reloadallYaml, this);
+
+	if (getParam<bool>("subscribe_scan", true))
+		scanSub = n.subscribe("scan", inputQueueSize, &Mapper::gotScan, this);
+	if (getParam<bool>("subscribe_cloud", true))
+		cloudSub = n.subscribe("cloud_in", inputQueueSize, &Mapper::gotCloud, this);
 
 	// refreshing tf transform thread
 	publishThread = boost::thread(boost::bind(&Mapper::publishLoop, this, tfRefreshPeriod));
@@ -1180,7 +1180,7 @@ void Mapper::publishLoop(double publishPeriod)
 
 void Mapper::publishTransform()
 {
-	if(processingNewCloud == false && publishMapTf == true)
+	if(processingNewCloud == false && publishMapTf == true && !lastPoinCloudTime.isZero())
 	{
 		publishLock.lock();
     ros::Time stamp = ros::Time::now();


### PR DESCRIPTION
@kubelva 

This is reaaaaaalllllyyyyy strange.

Adding the 6th publisher triggers a segfault in the SubT simulator environment.

The circumstances I observed that are required for this to happen are:

- have periodic TF publishing on
- have `/enable_statistics` set to true (so it's probably related to https://github.com/ros/ros_comm/issues/1329)
- have a TF broadcaster and listener in the code
- publish transforms in a separate thread
- start the TF listener before the publishing thread
- declare 6 or more publishers before starting the publishing thread

As I said, this is really weird and is probably some kind of race condition in ROS internals caused by the use of `/enable_statistics` (as the referenced issue suggests).

Here is a Minimal Segfaulting Example (notice that it only segfaults if I have the SubT simulator running; I tried both with `/use_sim_time` set to false and with simulated clock published by rosbag, but neither did trigger this behavior).

```c++
#include <ros/ros.h>
#include <std_msgs/Bool.h>
#include <nav_msgs/Odometry.h>
#include <sensor_msgs/PointCloud2.h>
#include <diagnostic_msgs/DiagnosticArray.h>
#include <boost/thread.hpp>
#include <tf/transform_broadcaster.h>
#include <tf/transform_listener.h>

void pub(tf::TransformBroadcaster& broad)
{ 
        ros::Rate r(10);
        while (ros::ok())
        {
           tf::StampedTransform t;
           broad.sendTransform(t);
           r.sleep();
         }
}

int main(int argc, char** argv)
{
        ros::init(argc, argv, "asd");

        tf::TransformListener ear(ros::Duration(30), true);
        tf::TransformBroadcaster broad;

        ros::NodeHandle n;
        ros::Publisher mapPub = n.advertise<sensor_msgs::PointCloud2>("point_map", 2, true);
        ros::Publisher scanPub = n.advertise<sensor_msgs::PointCloud2>("corrected_scan", 2, true);
        ros::Publisher outlierPub = n.advertise<sensor_msgs::PointCloud2>("outliers", 2, true);
        ros::Publisher odomPub = n.advertise<nav_msgs::Odometry>("icp_odom", 50, true);
        ros::Publisher odomErrorPub = n.advertise<nav_msgs::Odometry>("icp_error_odom", 50, true);
        ros::Publisher diagPub = n.advertise<diagnostic_msgs::DiagnosticArray>("icp_diagnostics", 2, true); // 6th publisher -> death

        boost::thread pubThread = boost::thread(boost::bind(&pub, broad));

        ros::spin();

        pubThread.join();
}
```

I fixed this by checking in the publishing thread whether there is some transform to be published (which makes sense even otherwise). This apparently puts the race condition away, although I don't know why.

I also moved subscriber creation after the publishers, which is a good habit, so that you don't process messages before the publishers are ready.